### PR TITLE
fix:适配RN0.77,解决Cannot read property source of undefined的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@react-native-oh-tpl/react-native-slider",
-  "version": "0.11.0-0.1.5",
+  "name": "@react-native-ohos/react-native-slider",
+  "version": "0.11.0",
   "description": "A pure JavaScript <Slider /> component for react-native",
   "main": "lib/Slider.js",
   "files": [

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 
 import PropTypes from 'prop-types';
-import { ViewPropTypes } from 'deprecated-react-native-prop-types';
+import { ViewPropTypes, ImagePropTypes} from 'deprecated-react-native-prop-types';
 
 const TRACK_SIZE = 4;
 const THUMB_SIZE = 20;
@@ -146,7 +146,7 @@ export default class Slider extends PureComponent {
     /**
      * Sets an image for the thumb.
      */
-    thumbImage: Image.propTypes.source,
+    thumbImage: ImagePropTypes.source,
 
     /**
      * Set this to true to visually see the thumb touch rect in green.


### PR DESCRIPTION
适配RN0.77,解决Cannot read property source of undefined的问题

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
-  [x] 更新了 JS/TS 代码 (如有)

